### PR TITLE
fix: Corrige erro de referência à variável `hmac`

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -186,7 +186,7 @@ function verify(input, key, method, type, signature) {
 function sign(input, key, method, type) {
   var base64str;
   if(type === "hmac") {
-    hmac = cjshmac[method](input, key);
+    const hmac = cjshmac[method](input, key);
     base64str = crypto.enc.Base64.stringify(hmac)
   }
   else if(type == "sign") {

--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -98,16 +98,6 @@ jwt.decode = function jwt_decode(token, key, noVerify, algorithm) {
     if ( ! verify(signingInput, key, signingMethod, signingType, signatureSeg) ) {
       throw new Error('Signature verification failed');
     }
-
-    // Support for nbf and exp claims.
-    // According to the RFC, they should be in seconds.
-    if (payload.nbf && Date.now() < payload.nbf*1000) {
-      throw new Error('Token not yet active');
-    }
-
-    if (payload.exp && Date.now() > payload.exp*1000) {
-      throw new Error('Token expired');
-    }
   }
 
   return payload;


### PR DESCRIPTION
Corrige erro `ReferenceError: hmac is not defined`  que ocorre ao usar o método `decode`.

Fix reference error `hmac is not defined`, that occurs when using the method  `decode`.